### PR TITLE
Implement basic address decode design

### DIFF
--- a/design/Address_Decode.dig
+++ b/design/Address_Decode.dig
@@ -5,23 +5,8 @@
   <visualElements>
     <visualElement>
       <elementName>74138.dig</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>A1-A3</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-600" y="160"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>A0</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-1120" y="120"/>
+      <elementAttributes/>
+      <pos x="520" y="100"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -31,7 +16,7 @@
           <string>A1</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="160"/>
+      <pos x="280" y="100"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -41,7 +26,7 @@
           <string>A2</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="200"/>
+      <pos x="280" y="140"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -51,7 +36,7 @@
           <string>A3</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="240"/>
+      <pos x="280" y="180"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -61,7 +46,7 @@
           <string>A4</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="280"/>
+      <pos x="280" y="560"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -71,7 +56,7 @@
           <string>A5</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="320"/>
+      <pos x="280" y="600"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -81,7 +66,22 @@
           <string>A6</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="360"/>
+      <pos x="280" y="640"/>
+    </visualElement>
+    <visualElement>
+      <elementName>74138.dig</elementName>
+      <elementAttributes/>
+      <pos x="520" y="560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>74138.dig</elementName>
+      <elementAttributes/>
+      <pos x="520" y="1020"/>
+    </visualElement>
+    <visualElement>
+      <elementName>74138.dig</elementName>
+      <elementAttributes/>
+      <pos x="520" y="1480"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -91,7 +91,7 @@
           <string>A7</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="400"/>
+      <pos x="280" y="1020"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -101,7 +101,7 @@
           <string>A8</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="440"/>
+      <pos x="280" y="1060"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -111,7 +111,7 @@
           <string>A9</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="480"/>
+      <pos x="280" y="1100"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -121,122 +121,7 @@
           <string>A10</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>R/~W</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-1120" y="0"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>AS</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-1120" y="40"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q3</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="320"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q0</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="200"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q1</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="240"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q2</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="280"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q4</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="360"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q5</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="400"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q6</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="440"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>~Q7</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-300" y="480"/>
-    </visualElement>
-    <visualElement>
-      <elementName>PullDown</elementName>
-      <elementAttributes/>
-      <pos x="-720" y="1480"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Ground</elementName>
-      <elementAttributes/>
-      <pos x="-620" y="1520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>VDD</elementName>
-      <elementAttributes/>
-      <pos x="-440" y="-300"/>
+      <pos x="280" y="1480"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -246,7 +131,7 @@
           <string>A11</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="560"/>
+      <pos x="280" y="1520"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -256,1452 +141,1757 @@
           <string>A12</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="600"/>
+      <pos x="280" y="1560"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>A13</string>
+          <string>A0</string>
         </entry>
       </elementAttributes>
-      <pos x="-1120" y="640"/>
-    </visualElement>
-    <visualElement>
-      <elementName>74138.dig</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>A4-A6</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-600" y="520"/>
+      <pos x="280" y="60"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q0</string>
+          <string>0000-0001</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="560"/>
+      <pos x="1060" y="140"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q1</string>
+          <string>~P1EN</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="600"/>
+      <pos x="1060" y="180"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q2</string>
+          <string>0004-0005</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="640"/>
+      <pos x="1060" y="220"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q3</string>
+          <string>~ACIAEN</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="680"/>
+      <pos x="1060" y="260"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q4</string>
+          <string>0008-0009</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="720"/>
+      <pos x="1060" y="300"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q5</string>
+          <string>~P2EN</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="760"/>
+      <pos x="1060" y="340"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q6</string>
+          <string>~P3EN</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="800"/>
+      <pos x="1060" y="380"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q7</string>
+          <string>~P4EN</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="840"/>
-    </visualElement>
-    <visualElement>
-      <elementName>74138.dig</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>A11-A13</string>
-        </entry>
-      </elementAttributes>
-      <pos x="-600" y="1120"/>
+      <pos x="1060" y="420"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q0</string>
+          <string>0000-000F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1160"/>
+      <pos x="1060" y="600"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q1</string>
+          <string>0010-001F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1200"/>
+      <pos x="1060" y="640"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q2</string>
+          <string>0020-002F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1240"/>
+      <pos x="1060" y="680"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q3</string>
+          <string>0030-003F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1280"/>
+      <pos x="1060" y="720"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q4</string>
+          <string>0040-004F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1320"/>
+      <pos x="1060" y="760"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q5</string>
+          <string>0050-005F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1360"/>
+      <pos x="1060" y="800"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q6</string>
+          <string>0060-006F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1400"/>
+      <pos x="1060" y="840"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>~Q7</string>
+          <string>0070-007F</string>
         </entry>
       </elementAttributes>
-      <pos x="-300" y="1440"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NOr</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-        <entry>
-          <string>Inputs</string>
-          <int>4</int>
-        </entry>
-      </elementAttributes>
-      <pos x="-60" y="860"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NOr</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-        <entry>
-          <string>Inputs</string>
-          <int>3</int>
-        </entry>
-      </elementAttributes>
-      <pos x="-60" y="1080"/>
-    </visualElement>
-    <visualElement>
-      <elementName>And</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="960"/>
-    </visualElement>
-    <visualElement>
-      <elementName>And</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-        <entry>
-          <string>Inputs</string>
-          <int>4</int>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="140"/>
+      <pos x="1060" y="880"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>ACIA CS0</string>
+          <string>0000-007F</string>
         </entry>
       </elementAttributes>
-      <pos x="460" y="-40"/>
-    </visualElement>
-    <visualElement>
-      <elementName>And</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-        <entry>
-          <string>Inputs</string>
-          <int>3</int>
-        </entry>
-      </elementAttributes>
-      <pos x="400" y="340"/>
+      <pos x="1060" y="1060"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>RTC CS1</string>
+          <string>0080-00FF</string>
         </entry>
       </elementAttributes>
-      <pos x="740" y="360"/>
+      <pos x="1060" y="1100"/>
     </visualElement>
     <visualElement>
-      <elementName>Not</elementName>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0100-017F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1140"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0180-01FF</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1180"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0200-027F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1220"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0280-02FF</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1260"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0300-037F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1300"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0380-03FF</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1340"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A0K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1520"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A1K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A2K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1600"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A3K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1640"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A4K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1680"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A5K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1720"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A6K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A7K</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1060" y="1800"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
       <elementAttributes>
         <entry>
           <string>rotation</string>
           <rotation rotation="3"/>
         </entry>
       </elementAttributes>
-      <pos x="600" y="440"/>
+      <pos x="680" y="1480"/>
     </visualElement>
     <visualElement>
-      <elementName>Or</elementName>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="3"/>
+        </entry>
+      </elementAttributes>
+      <pos x="680" y="560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="3"/>
+        </entry>
+      </elementAttributes>
+      <pos x="680" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="3"/>
+        </entry>
+      </elementAttributes>
+      <pos x="680" y="1020"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="300"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1220"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1680"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="380"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="840"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="220"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="680"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1140"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1600"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1640"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1300"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="480" y="1760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>And</elementName>
       <elementAttributes>
         <entry>
           <string>wideShape</string>
           <boolean>true</boolean>
         </entry>
+        <entry>
+          <string>Inputs</string>
+          <int>4</int>
+        </entry>
       </elementAttributes>
-      <pos x="540" y="800"/>
+      <pos x="1340" y="1700"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>RAM1 ~CS</string>
+          <string>~ROMCS</string>
         </entry>
       </elementAttributes>
-      <pos x="1040" y="600"/>
+      <pos x="1520" y="1740"/>
+    </visualElement>
+    <visualElement>
+      <elementName>And</elementName>
+      <elementAttributes>
+        <entry>
+          <string>wideShape</string>
+          <boolean>true</boolean>
+        </entry>
+      </elementAttributes>
+      <pos x="1340" y="1620"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>~RAM2CS</string>
+        </entry>
+      </elementAttributes>
+      <pos x="1520" y="1640"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>ROM ~CS</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 ~ROMCS
+1   x   x   0
+0   x   x   1</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="60"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
           <string>RAM2 ~CS</string>
         </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 ~RAM2CS
+1   x   x   1
+0   0   x   1
+0   1   x   0
+</dataString>
+          </testData>
+        </entry>
       </elementAttributes>
-      <pos x="1040" y="800"/>
+      <pos x="0" y="200"/>
     </visualElement>
     <visualElement>
-      <elementName>Out</elementName>
+      <elementName>Testcase</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>ROM ~CE</string>
+          <string>RAM1 ~CS</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 ~RAM1CS
+# 1000 - 1FFF is ROM
+1   x   x   x  x  x  x  x  x  1
+# 0800 - 0FFF is RAM2
+0   1   x   x  x  x  x  x  x  1
+# 0000 - 07FF is RAM1, with exceptions
+0   0   1   x  x  x  x  x  x  0
+0   0   0   1  x  x  x  x  x  0
+0   0   0   0  1  1  x  x  x  0
+0   0   0   0  1  0  1  x  x  0
+0   0   0   0  1  0  0  1  x  0
+0   0   0   0  1  0  0  0  1  0
+# 0100 - 010F is RTC
+0   0   0   0  1  0  0  0  0  1
+# 80 - FF is external RAM
+0   0   0   0  0  1  x  x  x  0
+# 00 - 7F is internal RAM
+0   0   0   0  0  0  x  x  x  1
+</dataString>
+          </testData>
         </entry>
       </elementAttributes>
-      <pos x="1040" y="1160"/>
+      <pos x="0" y="320"/>
     </visualElement>
     <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-60" y="140"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-240" y="160"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-300" y="520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-200" y="1480"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-140" y="1500"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="-80" y="1520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Or</elementName>
+      <elementName>And</elementName>
       <elementAttributes>
         <entry>
           <string>wideShape</string>
           <boolean>true</boolean>
         </entry>
       </elementAttributes>
-      <pos x="540" y="600"/>
+      <pos x="1340" y="1520"/>
     </visualElement>
     <visualElement>
       <elementName>Out</elementName>
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>ACIA CS1</string>
+          <string>~RAMBANK1CS</string>
         </entry>
       </elementAttributes>
-      <pos x="460" y="0"/>
+      <pos x="1520" y="1540"/>
     </visualElement>
     <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>ACIA ~CS2</string>
-        </entry>
-      </elementAttributes>
-      <pos x="460" y="40"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>ACIA R/~W</string>
-        </entry>
-      </elementAttributes>
-      <pos x="460" y="-80"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>ACIA E</string>
-        </entry>
-      </elementAttributes>
-      <pos x="460" y="-120"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>ACIA RS</string>
-        </entry>
-      </elementAttributes>
-      <pos x="460" y="-160"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RTC CS2</string>
-        </entry>
-      </elementAttributes>
-      <pos x="740" y="320"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RTC ADDRESS WRITE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="740" y="280"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RTC READ</string>
-        </entry>
-      </elementAttributes>
-      <pos x="740" y="240"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RTC WRITE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="740" y="200"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
+      <elementName>74138.dig</elementName>
       <elementAttributes/>
-      <pos x="540" y="200"/>
+      <pos x="1540" y="560"/>
     </visualElement>
     <visualElement>
-      <elementName>Out</elementName>
+      <elementName>Ground</elementName>
       <elementAttributes>
         <entry>
-          <string>Label</string>
-          <string>RAM1 ~OE</string>
+          <string>rotation</string>
+          <rotation rotation="1"/>
         </entry>
       </elementAttributes>
-      <pos x="1040" y="560"/>
+      <pos x="1500" y="680"/>
     </visualElement>
     <visualElement>
-      <elementName>NAnd</elementName>
+      <elementName>Ground</elementName>
       <elementAttributes>
         <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
+          <string>rotation</string>
+          <rotation rotation="1"/>
         </entry>
       </elementAttributes>
-      <pos x="800" y="580"/>
+      <pos x="1500" y="840"/>
     </visualElement>
     <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RAM1 ~WE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="1040" y="520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NAnd</elementName>
-      <elementAttributes>
-        <entry>
-          <string>wideShape</string>
-          <boolean>true</boolean>
-        </entry>
-      </elementAttributes>
-      <pos x="800" y="780"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RAM2 ~WE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="1040" y="720"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>RAM2 ~OE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="1040" y="760"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>ROM ~OE</string>
-        </entry>
-      </elementAttributes>
-      <pos x="1040" y="1120"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="800" y="1160"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
-      <elementAttributes/>
-      <pos x="540" y="120"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Not</elementName>
+      <elementName>VDD</elementName>
       <elementAttributes>
         <entry>
           <string>rotation</string>
           <rotation rotation="3"/>
         </entry>
       </elementAttributes>
-      <pos x="400" y="0"/>
+      <pos x="1700" y="560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="1500" y="760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0100-010F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="600"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0110-011F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="640"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0120-012F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="680"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0130-013F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="720"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0140-014F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0150-015F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="800"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0160-016F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="840"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>0170-017F</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2080" y="880"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>RTCCS1</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2500" y="600"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>RTCCS2</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2500" y="660"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Not</elementName>
+      <elementAttributes/>
+      <pos x="2360" y="600"/>
+    </visualElement>
+    <visualElement>
+      <elementName>VDD</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="2460" y="660"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>RTC CS1</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 RTCCS1
+1   x   x   x  x  x  x  x  x  0
+0   1   x   x  x  x  x  x  x  0
+0   0   1   x  x  x  x  x  x  0
+0   0   0   1  x  x  x  x  1  0
+0   0   0   0  1  1  x  x  x  0
+0   0   0   0  1  0  1  x  x  0
+0   0   0   0  1  0  0  1  x  0
+0   0   0   0  1  0  0  0  0  1
+0   0   0   0  0  1  x  x  x  0
+0   0   0   0  0  0  1  x  x  0
+0   0   0   0  0  0  0  1  x  0
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="440"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>~RAM1CS</string>
+        </entry>
+      </elementAttributes>
+      <pos x="2560" y="1280"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NAnd</elementName>
+      <elementAttributes>
+        <entry>
+          <string>wideShape</string>
+          <boolean>true</boolean>
+        </entry>
+        <entry>
+          <string>inverterConfig</string>
+          <inverterConfig>
+            <string>In_3</string>
+          </inverterConfig>
+        </entry>
+        <entry>
+          <string>Inputs</string>
+          <int>3</int>
+        </entry>
+      </elementAttributes>
+      <pos x="2320" y="1260"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Pair 1 ~EN</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 A3 A2 A1 ~P1EN
+0   0   0   0  0  0  0  0  0  0  0  0  1
+0   0   0   0  0  0  0  0  0  0  0  1  0
+0   0   0   0  0  0  0  0  0  0  1  0  1
+0   0   0   0  0  0  0  0  0  0  1  1  1
+0   0   0   0  0  0  0  0  0  1  0  0  1
+0   0   0   0  0  0  0  0  0  1  0  1  1
+0   0   0   0  0  0  0  0  0  1  1  0  1
+0   0   0   0  0  0  0  0  0  1  1  1  1
+x   x   x   x  x  x  x  x  1  x  x  x  1
+x   x   x   x  x  x  x  1  0  x  x  x  1
+x   x   x   x  x  x  1  0  0  x  x  x  1
+x   x   x   x  x  1  0  0  0  x  x  x  1
+x   x   x   x  1  0  0  0  0  x  x  x  1
+x   x   x   1  0  0  0  0  0  x  x  x  1
+x   x   1   0  0  0  0  0  0  x  x  x  1
+x   1   0   0  0  0  0  0  0  x  x  x  1
+1   0   0   0  0  0  0  0  0  x  x  x  1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>ACIA ~EN</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 A3 A2 A1 ~ACIAEN
+0   0   0   0  0  0  0  0  0  0  0  0  1
+0   0   0   0  0  0  0  0  0  0  0  1  1
+0   0   0   0  0  0  0  0  0  0  1  0  1
+0   0   0   0  0  0  0  0  0  0  1  1  0
+0   0   0   0  0  0  0  0  0  1  0  0  1
+0   0   0   0  0  0  0  0  0  1  0  1  1
+0   0   0   0  0  0  0  0  0  1  1  0  1
+0   0   0   0  0  0  0  0  0  1  1  1  1
+x   x   x   x  x  x  x  x  1  x  x  x  1
+x   x   x   x  x  x  x  1  0  x  x  x  1
+x   x   x   x  x  x  1  0  0  x  x  x  1
+x   x   x   x  x  1  0  0  0  x  x  x  1
+x   x   x   x  1  0  0  0  0  x  x  x  1
+x   x   x   1  0  0  0  0  0  x  x  x  1
+x   x   1   0  0  0  0  0  0  x  x  x  1
+x   1   0   0  0  0  0  0  0  x  x  x  1
+1   0   0   0  0  0  0  0  0  x  x  x  1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="660"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Pair 2 ~EN</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 A3 A2 A1 ~P2EN
+0   0   0   0  0  0  0  0  0  0  0  0  1
+0   0   0   0  0  0  0  0  0  0  0  1  1
+0   0   0   0  0  0  0  0  0  0  1  0  1
+0   0   0   0  0  0  0  0  0  0  1  1  1
+0   0   0   0  0  0  0  0  0  1  0  0  1
+0   0   0   0  0  0  0  0  0  1  0  1  0
+0   0   0   0  0  0  0  0  0  1  1  0  1
+0   0   0   0  0  0  0  0  0  1  1  1  1
+x   x   x   x  x  x  x  x  1  x  x  x  1
+x   x   x   x  x  x  x  1  0  x  x  x  1
+x   x   x   x  x  x  1  0  0  x  x  x  1
+x   x   x   x  x  1  0  0  0  x  x  x  1
+x   x   x   x  1  0  0  0  0  x  x  x  1
+x   x   x   1  0  0  0  0  0  x  x  x  1
+x   x   1   0  0  0  0  0  0  x  x  x  1
+x   1   0   0  0  0  0  0  0  x  x  x  1
+1   0   0   0  0  0  0  0  0  x  x  x  1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="760"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Pair 3 ~EN</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 A3 A2 A1 ~P3EN
+0   0   0   0  0  0  0  0  0  0  0  0  1
+0   0   0   0  0  0  0  0  0  0  0  1  1
+0   0   0   0  0  0  0  0  0  0  1  0  1
+0   0   0   0  0  0  0  0  0  0  1  1  1
+0   0   0   0  0  0  0  0  0  1  0  0  1
+0   0   0   0  0  0  0  0  0  1  0  1  1
+0   0   0   0  0  0  0  0  0  1  1  0  0
+0   0   0   0  0  0  0  0  0  1  1  1  1
+x   x   x   x  x  x  x  x  1  x  x  x  1
+x   x   x   x  x  x  x  1  0  x  x  x  1
+x   x   x   x  x  x  1  0  0  x  x  x  1
+x   x   x   x  x  1  0  0  0  x  x  x  1
+x   x   x   x  1  0  0  0  0  x  x  x  1
+x   x   x   1  0  0  0  0  0  x  x  x  1
+x   x   1   0  0  0  0  0  0  x  x  x  1
+x   1   0   0  0  0  0  0  0  x  x  x  1
+1   0   0   0  0  0  0  0  0  x  x  x  1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="860"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Pair 4 ~EN</string>
+        </entry>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A12 A11 A10 A9 A8 A7 A6 A5 A4 A3 A2 A1 ~P4EN
+0   0   0   0  0  0  0  0  0  0  0  0  1
+0   0   0   0  0  0  0  0  0  0  0  1  1
+0   0   0   0  0  0  0  0  0  0  1  0  1
+0   0   0   0  0  0  0  0  0  0  1  1  1
+0   0   0   0  0  0  0  0  0  1  0  0  1
+0   0   0   0  0  0  0  0  0  1  0  1  1
+0   0   0   0  0  0  0  0  0  1  1  0  1
+0   0   0   0  0  0  0  0  0  1  1  1  0
+x   x   x   x  x  x  x  x  1  x  x  x  1
+x   x   x   x  x  x  x  1  0  x  x  x  1
+x   x   x   x  x  x  1  0  0  x  x  x  1
+x   x   x   x  x  1  0  0  0  x  x  x  1
+x   x   x   x  1  0  0  0  0  x  x  x  1
+x   x   x   1  0  0  0  0  0  x  x  x  1
+x   x   1   0  0  0  0  0  0  x  x  x  1
+x   1   0   0  0  0  0  0  0  x  x  x  1
+1   0   0   0  0  0  0  0  0  x  x  x  1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="0" y="960"/>
     </visualElement>
   </visualElements>
   <wires>
     <wire>
-      <p1 x="-480" y="640"/>
-      <p2 x="-300" y="640"/>
+      <p1 x="280" y="640"/>
+      <p2 x="460" y="640"/>
     </wire>
     <wire>
-      <p1 x="-680" y="640"/>
-      <p2 x="-600" y="640"/>
+      <p1 x="640" y="640"/>
+      <p2 x="1060" y="640"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="640"/>
-      <p2 x="-1080" y="640"/>
+      <p1 x="1300" y="640"/>
+      <p2 x="1540" y="640"/>
     </wire>
     <wire>
-      <p1 x="400" y="640"/>
-      <p2 x="540" y="640"/>
+      <p1 x="1660" y="640"/>
+      <p2 x="2080" y="640"/>
     </wire>
     <wire>
-      <p1 x="-720" y="1280"/>
-      <p2 x="-600" y="1280"/>
+      <p1 x="460" y="640"/>
+      <p2 x="520" y="640"/>
     </wire>
     <wire>
-      <p1 x="-480" y="1280"/>
-      <p2 x="-360" y="1280"/>
+      <p1 x="960" y="1920"/>
+      <p2 x="1240" y="1920"/>
     </wire>
     <wire>
-      <p1 x="-360" y="1280"/>
-      <p2 x="-300" y="1280"/>
+      <p1 x="2420" y="1280"/>
+      <p2 x="2560" y="1280"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="0"/>
-      <p2 x="300" y="0"/>
+      <p1 x="1460" y="1280"/>
+      <p2 x="2320" y="1280"/>
     </wire>
     <wire>
-      <p1 x="420" y="0"/>
-      <p2 x="460" y="0"/>
+      <p1 x="640" y="260"/>
+      <p2 x="1060" y="260"/>
     </wire>
     <wire>
-      <p1 x="300" y="0"/>
-      <p2 x="360" y="0"/>
+      <p1 x="420" y="260"/>
+      <p2 x="520" y="260"/>
     </wire>
     <wire>
-      <p1 x="-780" y="900"/>
-      <p2 x="-240" y="900"/>
+      <p1 x="1420" y="1540"/>
+      <p2 x="1460" y="1540"/>
     </wire>
     <wire>
-      <p1 x="40" y="900"/>
-      <p2 x="80" y="900"/>
+      <p1 x="1460" y="1540"/>
+      <p2 x="1520" y="1540"/>
     </wire>
     <wire>
-      <p1 x="-1060" y="1160"/>
-      <p2 x="-600" y="1160"/>
+      <p1 x="460" y="1800"/>
+      <p2 x="1040" y="1800"/>
     </wire>
     <wire>
-      <p1 x="-480" y="1160"/>
-      <p2 x="-380" y="1160"/>
+      <p1 x="1040" y="1800"/>
+      <p2 x="1060" y="1800"/>
     </wire>
     <wire>
-      <p1 x="-180" y="1160"/>
-      <p2 x="800" y="1160"/>
+      <p1 x="500" y="520"/>
+      <p2 x="1260" y="520"/>
     </wire>
     <wire>
-      <p1 x="840" y="1160"/>
-      <p2 x="1040" y="1160"/>
+      <p1 x="280" y="140"/>
+      <p2 x="520" y="140"/>
     </wire>
     <wire>
-      <p1 x="-380" y="1160"/>
-      <p2 x="-300" y="1160"/>
+      <p1 x="640" y="140"/>
+      <p2 x="1060" y="140"/>
     </wire>
     <wire>
-      <p1 x="-700" y="520"/>
-      <p2 x="-600" y="520"/>
+      <p1 x="640" y="1680"/>
+      <p2 x="980" y="1680"/>
     </wire>
     <wire>
-      <p1 x="-480" y="520"/>
-      <p2 x="-440" y="520"/>
+      <p1 x="480" y="1680"/>
+      <p2 x="520" y="1680"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="520"/>
-      <p2 x="-840" y="520"/>
+      <p1 x="980" y="1680"/>
+      <p2 x="1060" y="1680"/>
     </wire>
     <wire>
-      <p1 x="-260" y="520"/>
-      <p2 x="-200" y="520"/>
+      <p1 x="480" y="1300"/>
+      <p2 x="520" y="1300"/>
     </wire>
     <wire>
-      <p1 x="-380" y="520"/>
-      <p2 x="-300" y="520"/>
+      <p1 x="640" y="1300"/>
+      <p2 x="1060" y="1300"/>
     </wire>
     <wire>
-      <p1 x="640" y="520"/>
-      <p2 x="1040" y="520"/>
+      <p1 x="1460" y="1300"/>
+      <p2 x="2300" y="1300"/>
     </wire>
     <wire>
-      <p1 x="-200" y="520"/>
-      <p2 x="420" y="520"/>
+      <p1 x="940" y="1940"/>
+      <p2 x="1220" y="1940"/>
     </wire>
     <wire>
-      <p1 x="-420" y="140"/>
-      <p2 x="-60" y="140"/>
+      <p1 x="2460" y="660"/>
+      <p2 x="2500" y="660"/>
     </wire>
     <wire>
-      <p1 x="-20" y="140"/>
-      <p2 x="140" y="140"/>
+      <p1 x="280" y="1560"/>
+      <p2 x="520" y="1560"/>
     </wire>
     <wire>
-      <p1 x="740" y="780"/>
-      <p2 x="800" y="780"/>
+      <p1 x="640" y="1560"/>
+      <p2 x="920" y="1560"/>
     </wire>
     <wire>
-      <p1 x="-480" y="400"/>
-      <p2 x="-300" y="400"/>
+      <p1 x="1200" y="1560"/>
+      <p2 x="1340" y="1560"/>
     </wire>
     <wire>
-      <p1 x="-640" y="400"/>
-      <p2 x="-600" y="400"/>
+      <p1 x="920" y="1560"/>
+      <p2 x="1060" y="1560"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="400"/>
-      <p2 x="-780" y="400"/>
+      <p1 x="640" y="1180"/>
+      <p2 x="1060" y="1180"/>
     </wire>
     <wire>
-      <p1 x="-680" y="280"/>
-      <p2 x="-600" y="280"/>
+      <p1 x="420" y="1180"/>
+      <p2 x="520" y="1180"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="280"/>
-      <p2 x="-700" y="280"/>
+      <p1 x="2180" y="1180"/>
+      <p2 x="2300" y="1180"/>
     </wire>
     <wire>
-      <p1 x="-480" y="280"/>
-      <p2 x="-300" y="280"/>
+      <p1 x="2020" y="540"/>
+      <p2 x="2300" y="540"/>
     </wire>
     <wire>
-      <p1 x="300" y="280"/>
-      <p2 x="740" y="280"/>
+      <p1 x="460" y="800"/>
+      <p2 x="520" y="800"/>
     </wire>
     <wire>
-      <p1 x="-160" y="920"/>
-      <p2 x="-60" y="920"/>
+      <p1 x="640" y="800"/>
+      <p2 x="1060" y="800"/>
     </wire>
     <wire>
-      <p1 x="-700" y="-160"/>
-      <p2 x="460" y="-160"/>
+      <p1 x="1660" y="800"/>
+      <p2 x="2080" y="800"/>
     </wire>
     <wire>
-      <p1 x="-620" y="800"/>
-      <p2 x="-600" y="800"/>
+      <p1 x="1480" y="800"/>
+      <p2 x="1540" y="800"/>
     </wire>
     <wire>
-      <p1 x="-480" y="800"/>
-      <p2 x="-300" y="800"/>
+      <p1 x="280" y="1060"/>
+      <p2 x="520" y="1060"/>
     </wire>
     <wire>
-      <p1 x="420" y="800"/>
-      <p2 x="540" y="800"/>
+      <p1 x="640" y="1060"/>
+      <p2 x="760" y="1060"/>
     </wire>
     <wire>
-      <p1 x="900" y="800"/>
-      <p2 x="1040" y="800"/>
+      <p1 x="760" y="1060"/>
+      <p2 x="1000" y="1060"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="160"/>
-      <p2 x="-600" y="160"/>
+      <p1 x="1000" y="1060"/>
+      <p2 x="1060" y="1060"/>
     </wire>
     <wire>
-      <p1 x="-480" y="160"/>
-      <p2 x="-440" y="160"/>
+      <p1 x="460" y="420"/>
+      <p2 x="1060" y="420"/>
     </wire>
     <wire>
-      <p1 x="-200" y="160"/>
-      <p2 x="-180" y="160"/>
+      <p1 x="1260" y="1700"/>
+      <p2 x="1340" y="1700"/>
     </wire>
     <wire>
-      <p1 x="-400" y="160"/>
-      <p2 x="-240" y="160"/>
+      <p1 x="480" y="680"/>
+      <p2 x="520" y="680"/>
     </wire>
     <wire>
-      <p1 x="-180" y="160"/>
-      <p2 x="140" y="160"/>
+      <p1 x="640" y="680"/>
+      <p2 x="1060" y="680"/>
     </wire>
     <wire>
-      <p1 x="-640" y="1440"/>
-      <p2 x="-300" y="1440"/>
+      <p1 x="1500" y="680"/>
+      <p2 x="1540" y="680"/>
     </wire>
     <wire>
-      <p1 x="-1080" y="1060"/>
-      <p2 x="-280" y="1060"/>
+      <p1 x="1660" y="680"/>
+      <p2 x="2080" y="680"/>
     </wire>
     <wire>
-      <p1 x="320" y="-40"/>
-      <p2 x="400" y="-40"/>
+      <p1 x="920" y="1960"/>
+      <p2 x="1200" y="1960"/>
     </wire>
     <wire>
-      <p1 x="400" y="-40"/>
-      <p2 x="420" y="-40"/>
+      <p1 x="480" y="300"/>
+      <p2 x="520" y="300"/>
     </wire>
     <wire>
-      <p1 x="420" y="-40"/>
-      <p2 x="460" y="-40"/>
+      <p1 x="640" y="300"/>
+      <p2 x="1060" y="300"/>
     </wire>
     <wire>
-      <p1 x="-1120" y="40"/>
-      <p2 x="-680" y="40"/>
+      <p1 x="420" y="940"/>
+      <p2 x="760" y="940"/>
     </wire>
     <wire>
-      <p1 x="400" y="40"/>
-      <p2 x="460" y="40"/>
+      <p1 x="900" y="940"/>
+      <p2 x="1440" y="940"/>
     </wire>
     <wire>
-      <p1 x="-680" y="40"/>
-      <p2 x="300" y="40"/>
+      <p1 x="280" y="560"/>
+      <p2 x="500" y="560"/>
     </wire>
     <wire>
-      <p1 x="-720" y="680"/>
-      <p2 x="-600" y="680"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="680"/>
-      <p2 x="-300" y="680"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="1320"/>
-      <p2 x="-600" y="1320"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1320"/>
-      <p2 x="-300" y="1320"/>
-    </wire>
-    <wire>
-      <p1 x="-800" y="940"/>
-      <p2 x="-200" y="940"/>
-    </wire>
-    <wire>
-      <p1 x="-120" y="940"/>
-      <p2 x="-60" y="940"/>
-    </wire>
-    <wire>
-      <p1 x="-1080" y="1200"/>
-      <p2 x="-600" y="1200"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1200"/>
-      <p2 x="-320" y="1200"/>
-    </wire>
-    <wire>
-      <p1 x="-320" y="1200"/>
-      <p2 x="-300" y="1200"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="560"/>
-      <p2 x="-400" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="-740" y="560"/>
-      <p2 x="-600" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="560"/>
-      <p2 x="-1040" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="680" y="560"/>
-      <p2 x="1040" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="-400" y="560"/>
-      <p2 x="-300" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="220" y="180"/>
-      <p2 x="320" y="180"/>
-    </wire>
-    <wire>
-      <p1 x="620" y="820"/>
-      <p2 x="800" y="820"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="440"/>
-      <p2 x="-300" y="440"/>
-    </wire>
-    <wire>
-      <p1 x="-620" y="440"/>
-      <p2 x="-600" y="440"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="440"/>
-      <p2 x="-800" y="440"/>
-    </wire>
-    <wire>
-      <p1 x="-240" y="1080"/>
-      <p2 x="-60" y="1080"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="960"/>
-      <p2 x="140" y="960"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="320"/>
-      <p2 x="-420" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="-720" y="320"/>
-      <p2 x="-600" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="320"/>
-      <p2 x="-740" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="540" y="320"/>
-      <p2 x="740" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="-420" y="320"/>
-      <p2 x="-300" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="600" y="580"/>
-      <p2 x="740" y="580"/>
-    </wire>
-    <wire>
-      <p1 x="740" y="580"/>
-      <p2 x="800" y="580"/>
-    </wire>
-    <wire>
-      <p1 x="580" y="200"/>
-      <p2 x="740" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="360" y="200"/>
-      <p2 x="540" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="200"/>
-      <p2 x="-600" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="200"/>
-      <p2 x="-300" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="200"/>
-      <p2 x="140" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="-640" y="840"/>
-      <p2 x="-300" y="840"/>
-    </wire>
-    <wire>
-      <p1 x="440" y="840"/>
-      <p2 x="540" y="840"/>
-    </wire>
-    <wire>
-      <p1 x="-320" y="1480"/>
-      <p2 x="-200" y="1480"/>
-    </wire>
-    <wire>
-      <p1 x="-160" y="1480"/>
-      <p2 x="400" y="1480"/>
-    </wire>
-    <wire>
-      <p1 x="40" y="1100"/>
-      <p2 x="100" y="1100"/>
-    </wire>
-    <wire>
-      <p1 x="-160" y="1100"/>
-      <p2 x="-60" y="1100"/>
-    </wire>
-    <wire>
-      <p1 x="300" y="-80"/>
-      <p2 x="460" y="-80"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="720"/>
-      <p2 x="-300" y="720"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="720"/>
-      <p2 x="-600" y="720"/>
-    </wire>
-    <wire>
-      <p1 x="640" y="720"/>
-      <p2 x="1040" y="720"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1360"/>
-      <p2 x="-300" y="1360"/>
-    </wire>
-    <wire>
-      <p1 x="-640" y="1360"/>
-      <p2 x="-600" y="1360"/>
-    </wire>
-    <wire>
-      <p1 x="-820" y="980"/>
-      <p2 x="-160" y="980"/>
-    </wire>
-    <wire>
-      <p1 x="220" y="980"/>
-      <p2 x="260" y="980"/>
-    </wire>
-    <wire>
-      <p1 x="-180" y="340"/>
-      <p2 x="400" y="340"/>
-    </wire>
-    <wire>
-      <p1 x="-760" y="600"/>
-      <p2 x="-600" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="600"/>
-      <p2 x="-300" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="600"/>
-      <p2 x="-1060" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="600"/>
-      <p2 x="540" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="900" y="600"/>
-      <p2 x="1040" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="-680" y="1240"/>
-      <p2 x="-600" y="1240"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1240"/>
-      <p2 x="-340" y="1240"/>
-    </wire>
-    <wire>
-      <p1 x="-340" y="1240"/>
-      <p2 x="-300" y="1240"/>
-    </wire>
-    <wire>
-      <p1 x="-240" y="860"/>
-      <p2 x="-60" y="860"/>
-    </wire>
-    <wire>
-      <p1 x="80" y="220"/>
-      <p2 x="140" y="220"/>
-    </wire>
-    <wire>
-      <p1 x="-340" y="1500"/>
-      <p2 x="-140" y="1500"/>
-    </wire>
-    <wire>
-      <p1 x="-100" y="1500"/>
-      <p2 x="420" y="1500"/>
-    </wire>
-    <wire>
-      <p1 x="-1040" y="1120"/>
-      <p2 x="-600" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1120"/>
-      <p2 x="-440" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="-120" y="1120"/>
-      <p2 x="-60" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="-280" y="1120"/>
-      <p2 x="-180" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="680" y="1120"/>
-      <p2 x="1040" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="-640" y="480"/>
-      <p2 x="-300" y="480"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="480"/>
-      <p2 x="-820" y="480"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="100"/>
-      <p2 x="-440" y="100"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="360"/>
-      <p2 x="-300" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="360"/>
-      <p2 x="-600" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="360"/>
-      <p2 x="-760" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="360"/>
-      <p2 x="400" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="480" y="360"/>
-      <p2 x="540" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="600" y="360"/>
-      <p2 x="740" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="540" y="360"/>
-      <p2 x="600" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="100" y="1000"/>
-      <p2 x="140" y="1000"/>
-    </wire>
-    <wire>
-      <p1 x="620" y="620"/>
-      <p2 x="800" y="620"/>
-    </wire>
-    <wire>
-      <p1 x="360" y="240"/>
-      <p2 x="640" y="240"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="240"/>
-      <p2 x="-600" y="240"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="240"/>
-      <p2 x="-300" y="240"/>
-    </wire>
-    <wire>
-      <p1 x="640" y="240"/>
-      <p2 x="740" y="240"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="880"/>
-      <p2 x="-60" y="880"/>
-    </wire>
-    <wire>
-      <p1 x="-40" y="1520"/>
-      <p2 x="440" y="1520"/>
-    </wire>
-    <wire>
-      <p1 x="-360" y="1520"/>
-      <p2 x="-80" y="1520"/>
-    </wire>
-    <wire>
-      <p1 x="320" y="-120"/>
-      <p2 x="460" y="-120"/>
-    </wire>
-    <wire>
-      <p1 x="-620" y="1400"/>
-      <p2 x="-600" y="1400"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="1400"/>
-      <p2 x="-300" y="1400"/>
-    </wire>
-    <wire>
-      <p1 x="-640" y="760"/>
-      <p2 x="-600" y="760"/>
-    </wire>
-    <wire>
-      <p1 x="-480" y="760"/>
-      <p2 x="-300" y="760"/>
-    </wire>
-    <wire>
-      <p1 x="680" y="760"/>
-      <p2 x="1040" y="760"/>
-    </wire>
-    <wire>
-      <p1 x="-1120" y="120"/>
-      <p2 x="-700" y="120"/>
-    </wire>
-    <wire>
-      <p1 x="300" y="120"/>
-      <p2 x="540" y="120"/>
-    </wire>
-    <wire>
-      <p1 x="580" y="120"/>
-      <p2 x="680" y="120"/>
-    </wire>
-    <wire>
-      <p1 x="-840" y="1020"/>
-      <p2 x="-120" y="1020"/>
-    </wire>
-    <wire>
-      <p1 x="260" y="380"/>
-      <p2 x="400" y="380"/>
-    </wire>
-    <wire>
-      <p1 x="320" y="-120"/>
-      <p2 x="320" y="-40"/>
-    </wire>
-    <wire>
-      <p1 x="320" y="-40"/>
-      <p2 x="320" y="180"/>
-    </wire>
-    <wire>
-      <p1 x="640" y="240"/>
-      <p2 x="640" y="520"/>
-    </wire>
-    <wire>
-      <p1 x="640" y="520"/>
-      <p2 x="640" y="720"/>
-    </wire>
-    <wire>
-      <p1 x="260" y="380"/>
-      <p2 x="260" y="980"/>
-    </wire>
-    <wire>
-      <p1 x="-840" y="520"/>
-      <p2 x="-840" y="1020"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="880"/>
-      <p2 x="-200" y="940"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="200"/>
-      <p2 x="-200" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="940"/>
-      <p2 x="-200" y="960"/>
-    </wire>
-    <wire>
-      <p1 x="-200" y="360"/>
-      <p2 x="-200" y="520"/>
-    </wire>
-    <wire>
-      <p1 x="-780" y="400"/>
-      <p2 x="-780" y="900"/>
-    </wire>
-    <wire>
-      <p1 x="-1040" y="560"/>
-      <p2 x="-1040" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="-720" y="320"/>
-      <p2 x="-720" y="680"/>
-    </wire>
-    <wire>
-      <p1 x="-720" y="1280"/>
-      <p2 x="-720" y="1480"/>
-    </wire>
-    <wire>
-      <p1 x="-720" y="680"/>
-      <p2 x="-720" y="1280"/>
-    </wire>
-    <wire>
-      <p1 x="-400" y="160"/>
-      <p2 x="-400" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="80" y="220"/>
-      <p2 x="80" y="900"/>
-    </wire>
-    <wire>
-      <p1 x="400" y="640"/>
-      <p2 x="400" y="1480"/>
-    </wire>
-    <wire>
-      <p1 x="400" y="-40"/>
-      <p2 x="400" y="0"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="100"/>
-      <p2 x="-660" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="360"/>
-      <p2 x="-660" y="720"/>
-    </wire>
-    <wire>
-      <p1 x="-660" y="720"/>
-      <p2 x="-660" y="1320"/>
-    </wire>
-    <wire>
-      <p1 x="-340" y="1240"/>
-      <p2 x="-340" y="1500"/>
-    </wire>
-    <wire>
-      <p1 x="-280" y="1060"/>
-      <p2 x="-280" y="1120"/>
-    </wire>
-    <wire>
-      <p1 x="600" y="360"/>
-      <p2 x="600" y="440"/>
-    </wire>
-    <wire>
-      <p1 x="600" y="480"/>
-      <p2 x="600" y="580"/>
-    </wire>
-    <wire>
-      <p1 x="540" y="320"/>
-      <p2 x="540" y="360"/>
-    </wire>
-    <wire>
-      <p1 x="-800" y="440"/>
-      <p2 x="-800" y="940"/>
-    </wire>
-    <wire>
-      <p1 x="-160" y="920"/>
-      <p2 x="-160" y="980"/>
-    </wire>
-    <wire>
-      <p1 x="-160" y="980"/>
-      <p2 x="-160" y="1100"/>
-    </wire>
-    <wire>
-      <p1 x="-740" y="320"/>
-      <p2 x="-740" y="560"/>
-    </wire>
-    <wire>
-      <p1 x="-1060" y="600"/>
-      <p2 x="-1060" y="1160"/>
-    </wire>
-    <wire>
-      <p1 x="-420" y="140"/>
-      <p2 x="-420" y="320"/>
-    </wire>
-    <wire>
-      <p1 x="100" y="1000"/>
-      <p2 x="100" y="1100"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="520"/>
-      <p2 x="420" y="600"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="800"/>
-      <p2 x="420" y="1500"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="-40"/>
-      <p2 x="420" y="0"/>
-    </wire>
-    <wire>
-      <p1 x="740" y="580"/>
-      <p2 x="740" y="780"/>
-    </wire>
-    <wire>
-      <p1 x="-680" y="40"/>
-      <p2 x="-680" y="280"/>
-    </wire>
-    <wire>
-      <p1 x="-680" y="280"/>
-      <p2 x="-680" y="640"/>
-    </wire>
-    <wire>
-      <p1 x="-680" y="640"/>
-      <p2 x="-680" y="1240"/>
-    </wire>
-    <wire>
-      <p1 x="-360" y="1280"/>
-      <p2 x="-360" y="1520"/>
-    </wire>
-    <wire>
-      <p1 x="360" y="0"/>
-      <p2 x="360" y="200"/>
-    </wire>
-    <wire>
-      <p1 x="360" y="200"/>
-      <p2 x="360" y="240"/>
-    </wire>
-    <wire>
-      <p1 x="680" y="120"/>
+      <p1 x="640" y="560"/>
       <p2 x="680" y="560"/>
     </wire>
     <wire>
-      <p1 x="680" y="560"/>
-      <p2 x="680" y="760"/>
+      <p1 x="1260" y="560"/>
+      <p2 x="1540" y="560"/>
     </wire>
     <wire>
-      <p1 x="680" y="760"/>
-      <p2 x="680" y="1120"/>
+      <p1 x="1660" y="560"/>
+      <p2 x="1700" y="560"/>
     </wire>
     <wire>
-      <p1 x="-620" y="440"/>
-      <p2 x="-620" y="800"/>
+      <p1 x="500" y="560"/>
+      <p2 x="520" y="560"/>
     </wire>
     <wire>
-      <p1 x="-620" y="1400"/>
-      <p2 x="-620" y="1520"/>
+      <p1 x="1040" y="1840"/>
+      <p2 x="1320" y="1840"/>
     </wire>
     <wire>
-      <p1 x="-620" y="800"/>
-      <p2 x="-620" y="1400"/>
+      <p1 x="280" y="180"/>
+      <p2 x="520" y="180"/>
     </wire>
     <wire>
-      <p1 x="300" y="40"/>
-      <p2 x="300" y="120"/>
+      <p1 x="640" y="180"/>
+      <p2 x="1060" y="180"/>
     </wire>
     <wire>
-      <p1 x="300" y="-80"/>
-      <p2 x="300" y="0"/>
+      <p1 x="640" y="1720"/>
+      <p2 x="1000" y="1720"/>
     </wire>
     <wire>
-      <p1 x="300" y="120"/>
-      <p2 x="300" y="280"/>
+      <p1 x="460" y="1720"/>
+      <p2 x="520" y="1720"/>
     </wire>
     <wire>
-      <p1 x="-240" y="860"/>
-      <p2 x="-240" y="900"/>
+      <p1 x="1280" y="1720"/>
+      <p2 x="1340" y="1720"/>
     </wire>
     <wire>
-      <p1 x="-240" y="900"/>
-      <p2 x="-240" y="1080"/>
+      <p1 x="1000" y="1720"/>
+      <p2 x="1060" y="1720"/>
     </wire>
     <wire>
-      <p1 x="-820" y="480"/>
-      <p2 x="-820" y="980"/>
+      <p1 x="420" y="440"/>
+      <p2 x="760" y="440"/>
     </wire>
     <wire>
-      <p1 x="-180" y="160"/>
-      <p2 x="-180" y="340"/>
+      <p1 x="460" y="1340"/>
+      <p2 x="1060" y="1340"/>
     </wire>
     <wire>
-      <p1 x="-180" y="1120"/>
-      <p2 x="-180" y="1160"/>
+      <p1 x="900" y="1980"/>
+      <p2 x="1180" y="1980"/>
     </wire>
     <wire>
-      <p1 x="-1080" y="640"/>
-      <p2 x="-1080" y="1060"/>
+      <p1 x="640" y="1600"/>
+      <p2 x="940" y="1600"/>
     </wire>
     <wire>
-      <p1 x="-1080" y="1060"/>
-      <p2 x="-1080" y="1200"/>
+      <p1 x="480" y="1600"/>
+      <p2 x="520" y="1600"/>
     </wire>
     <wire>
-      <p1 x="-440" y="-300"/>
-      <p2 x="-440" y="100"/>
+      <p1 x="940" y="1600"/>
+      <p2 x="1060" y="1600"/>
     </wire>
     <wire>
-      <p1 x="-440" y="160"/>
-      <p2 x="-440" y="520"/>
+      <p1 x="480" y="1220"/>
+      <p2 x="520" y="1220"/>
     </wire>
     <wire>
-      <p1 x="-440" y="100"/>
-      <p2 x="-440" y="160"/>
+      <p1 x="640" y="1220"/>
+      <p2 x="1060" y="1220"/>
     </wire>
     <wire>
-      <p1 x="-440" y="520"/>
-      <p2 x="-440" y="1120"/>
+      <p1 x="1020" y="1860"/>
+      <p2 x="1300" y="1860"/>
     </wire>
     <wire>
-      <p1 x="-760" y="360"/>
-      <p2 x="-760" y="600"/>
+      <p1 x="280" y="1480"/>
+      <p2 x="520" y="1480"/>
     </wire>
     <wire>
-      <p1 x="-120" y="940"/>
-      <p2 x="-120" y="1020"/>
+      <p1 x="640" y="1480"/>
+      <p2 x="680" y="1480"/>
     </wire>
     <wire>
-      <p1 x="-120" y="1020"/>
-      <p2 x="-120" y="1120"/>
+      <p1 x="480" y="840"/>
+      <p2 x="520" y="840"/>
     </wire>
     <wire>
-      <p1 x="440" y="840"/>
-      <p2 x="440" y="1520"/>
+      <p1 x="640" y="840"/>
+      <p2 x="1060" y="840"/>
     </wire>
     <wire>
-      <p1 x="-700" y="280"/>
-      <p2 x="-700" y="520"/>
+      <p1 x="1500" y="840"/>
+      <p2 x="1540" y="840"/>
     </wire>
     <wire>
-      <p1 x="-700" y="-160"/>
-      <p2 x="-700" y="120"/>
+      <p1 x="1660" y="840"/>
+      <p2 x="2080" y="840"/>
     </wire>
     <wire>
-      <p1 x="-380" y="520"/>
-      <p2 x="-380" y="1160"/>
+      <p1 x="280" y="1100"/>
+      <p2 x="520" y="1100"/>
     </wire>
     <wire>
-      <p1 x="-640" y="400"/>
-      <p2 x="-640" y="480"/>
+      <p1 x="640" y="1100"/>
+      <p2 x="1060" y="1100"/>
     </wire>
     <wire>
-      <p1 x="-640" y="760"/>
-      <p2 x="-640" y="840"/>
+      <p1 x="1420" y="1740"/>
+      <p2 x="1520" y="1740"/>
     </wire>
     <wire>
-      <p1 x="-640" y="1360"/>
-      <p2 x="-640" y="1440"/>
+      <p1 x="640" y="720"/>
+      <p2 x="1060" y="720"/>
     </wire>
     <wire>
-      <p1 x="-320" y="1200"/>
-      <p2 x="-320" y="1480"/>
+      <p1 x="420" y="720"/>
+      <p2 x="520" y="720"/>
+    </wire>
+    <wire>
+      <p1 x="1440" y="720"/>
+      <p2 x="1540" y="720"/>
+    </wire>
+    <wire>
+      <p1 x="1660" y="720"/>
+      <p2 x="2080" y="720"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="340"/>
+      <p2 x="1060" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="340"/>
+      <p2 x="520" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="1220" y="1620"/>
+      <p2 x="1340" y="1620"/>
+    </wire>
+    <wire>
+      <p1 x="1000" y="980"/>
+      <p2 x="1460" y="980"/>
+    </wire>
+    <wire>
+      <p1 x="280" y="600"/>
+      <p2 x="480" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="600"/>
+      <p2 x="760" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="1280" y="600"/>
+      <p2 x="1540" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="1660" y="600"/>
+      <p2 x="2020" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="2400" y="600"/>
+      <p2 x="2500" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="2300" y="600"/>
+      <p2 x="2360" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="760" y="600"/>
+      <p2 x="1060" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="2020" y="600"/>
+      <p2 x="2080" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="600"/>
+      <p2 x="520" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="1000" y="1880"/>
+      <p2 x="1280" y="1880"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="220"/>
+      <p2 x="520" y="220"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="220"/>
+      <p2 x="1060" y="220"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1760"/>
+      <p2 x="1020" y="1760"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="1760"/>
+      <p2 x="520" y="1760"/>
+    </wire>
+    <wire>
+      <p1 x="1300" y="1760"/>
+      <p2 x="1340" y="1760"/>
+    </wire>
+    <wire>
+      <p1 x="1020" y="1760"/>
+      <p2 x="1060" y="1760"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="480"/>
+      <p2 x="1300" y="480"/>
+    </wire>
+    <wire>
+      <p1 x="280" y="100"/>
+      <p2 x="520" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="100"/>
+      <p2 x="680" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1640"/>
+      <p2 x="960" y="1640"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="1640"/>
+      <p2 x="520" y="1640"/>
+    </wire>
+    <wire>
+      <p1 x="1420" y="1640"/>
+      <p2 x="1520" y="1640"/>
+    </wire>
+    <wire>
+      <p1 x="960" y="1640"/>
+      <p2 x="1060" y="1640"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1260"/>
+      <p2 x="1060" y="1260"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="1260"/>
+      <p2 x="520" y="1260"/>
+    </wire>
+    <wire>
+      <p1 x="2180" y="1260"/>
+      <p2 x="2320" y="1260"/>
+    </wire>
+    <wire>
+      <p1 x="980" y="1900"/>
+      <p2 x="1260" y="1900"/>
+    </wire>
+    <wire>
+      <p1 x="280" y="1520"/>
+      <p2 x="520" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="1180" y="1520"/>
+      <p2 x="1340" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1520"/>
+      <p2 x="760" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="900" y="1520"/>
+      <p2 x="1060" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="760" y="1520"/>
+      <p2 x="900" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="880"/>
+      <p2 x="1060" y="880"/>
+    </wire>
+    <wire>
+      <p1 x="1480" y="880"/>
+      <p2 x="2080" y="880"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="1140"/>
+      <p2 x="520" y="1140"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1140"/>
+      <p2 x="900" y="1140"/>
+    </wire>
+    <wire>
+      <p1 x="900" y="1140"/>
+      <p2 x="1060" y="1140"/>
+    </wire>
+    <wire>
+      <p1 x="1320" y="1780"/>
+      <p2 x="1340" y="1780"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="500"/>
+      <p2 x="1280" y="500"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="760"/>
+      <p2 x="520" y="760"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="760"/>
+      <p2 x="1060" y="760"/>
+    </wire>
+    <wire>
+      <p1 x="1500" y="760"/>
+      <p2 x="1540" y="760"/>
+    </wire>
+    <wire>
+      <p1 x="1660" y="760"/>
+      <p2 x="2080" y="760"/>
+    </wire>
+    <wire>
+      <p1 x="420" y="1400"/>
+      <p2 x="760" y="1400"/>
+    </wire>
+    <wire>
+      <p1 x="1240" y="1660"/>
+      <p2 x="1340" y="1660"/>
+    </wire>
+    <wire>
+      <p1 x="280" y="1020"/>
+      <p2 x="520" y="1020"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="1020"/>
+      <p2 x="680" y="1020"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="380"/>
+      <p2 x="520" y="380"/>
+    </wire>
+    <wire>
+      <p1 x="640" y="380"/>
+      <p2 x="1060" y="380"/>
+    </wire>
+    <wire>
+      <p1 x="1280" y="1720"/>
+      <p2 x="1280" y="1880"/>
+    </wire>
+    <wire>
+      <p1 x="1280" y="500"/>
+      <p2 x="1280" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="960" y="1640"/>
+      <p2 x="960" y="1920"/>
+    </wire>
+    <wire>
+      <p1 x="1220" y="1620"/>
+      <p2 x="1220" y="1940"/>
+    </wire>
+    <wire>
+      <p1 x="900" y="1520"/>
+      <p2 x="900" y="1980"/>
+    </wire>
+    <wire>
+      <p1 x="900" y="940"/>
+      <p2 x="900" y="1140"/>
+    </wire>
+    <wire>
+      <p1 x="2180" y="1180"/>
+      <p2 x="2180" y="1260"/>
+    </wire>
+    <wire>
+      <p1 x="1480" y="800"/>
+      <p2 x="1480" y="880"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="1720"/>
+      <p2 x="460" y="1800"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="340"/>
+      <p2 x="460" y="420"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="800"/>
+      <p2 x="460" y="880"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="1260"/>
+      <p2 x="460" y="1340"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="480"/>
+      <p2 x="460" y="640"/>
+    </wire>
+    <wire>
+      <p1 x="1040" y="1800"/>
+      <p2 x="1040" y="1840"/>
+    </wire>
+    <wire>
+      <p1 x="1300" y="1760"/>
+      <p2 x="1300" y="1860"/>
+    </wire>
+    <wire>
+      <p1 x="1300" y="480"/>
+      <p2 x="1300" y="640"/>
+    </wire>
+    <wire>
+      <p1 x="980" y="1680"/>
+      <p2 x="980" y="1900"/>
+    </wire>
+    <wire>
+      <p1 x="1240" y="1660"/>
+      <p2 x="1240" y="1920"/>
+    </wire>
+    <wire>
+      <p1 x="920" y="1560"/>
+      <p2 x="920" y="1960"/>
+    </wire>
+    <wire>
+      <p1 x="1180" y="1520"/>
+      <p2 x="1180" y="1980"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="500"/>
+      <p2 x="480" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="1440" y="720"/>
+      <p2 x="1440" y="940"/>
+    </wire>
+    <wire>
+      <p1 x="420" y="1180"/>
+      <p2 x="420" y="1400"/>
+    </wire>
+    <wire>
+      <p1 x="420" y="260"/>
+      <p2 x="420" y="440"/>
+    </wire>
+    <wire>
+      <p1 x="420" y="720"/>
+      <p2 x="420" y="940"/>
+    </wire>
+    <wire>
+      <p1 x="2020" y="540"/>
+      <p2 x="2020" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="1320" y="1780"/>
+      <p2 x="1320" y="1840"/>
+    </wire>
+    <wire>
+      <p1 x="1000" y="1720"/>
+      <p2 x="1000" y="1880"/>
+    </wire>
+    <wire>
+      <p1 x="1000" y="980"/>
+      <p2 x="1000" y="1060"/>
+    </wire>
+    <wire>
+      <p1 x="1260" y="1700"/>
+      <p2 x="1260" y="1900"/>
+    </wire>
+    <wire>
+      <p1 x="1260" y="520"/>
+      <p2 x="1260" y="560"/>
+    </wire>
+    <wire>
+      <p1 x="940" y="1600"/>
+      <p2 x="940" y="1940"/>
+    </wire>
+    <wire>
+      <p1 x="1200" y="1560"/>
+      <p2 x="1200" y="1960"/>
+    </wire>
+    <wire>
+      <p1 x="500" y="520"/>
+      <p2 x="500" y="560"/>
+    </wire>
+    <wire>
+      <p1 x="1460" y="1300"/>
+      <p2 x="1460" y="1540"/>
+    </wire>
+    <wire>
+      <p1 x="1460" y="980"/>
+      <p2 x="1460" y="1280"/>
+    </wire>
+    <wire>
+      <p1 x="760" y="1400"/>
+      <p2 x="760" y="1520"/>
+    </wire>
+    <wire>
+      <p1 x="760" y="440"/>
+      <p2 x="760" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="760" y="940"/>
+      <p2 x="760" y="1060"/>
+    </wire>
+    <wire>
+      <p1 x="2300" y="540"/>
+      <p2 x="2300" y="600"/>
+    </wire>
+    <wire>
+      <p1 x="2300" y="600"/>
+      <p2 x="2300" y="1180"/>
+    </wire>
+    <wire>
+      <p1 x="1020" y="1760"/>
+      <p2 x="1020" y="1860"/>
     </wire>
   </wires>
   <measurementOrdering/>


### PR DESCRIPTION
- Add 74138s to do basic address decoding in stages:
  - Select 1K ranges of 8K address space
  - For $0000-$0800 bottom 1K range, select 128 byte ($7F) chunks
  - For $0000-$007F bottom 128 byte range, select 16 byte ($F) chunks
  - For $0000-$000F bottom 16 byte range, select 2 byte chunks for ACIA
    and 4 2-byte pairs P1-P4 for external expansion.
  - For $0100-$017F 128 byte range, select 16 byte ($F) chunks
  - Map $0100-$010F 16 byte chunk to RTC
  - Map $0080-$00FF to RAM1
  - Map $0110-$07FF to RAM1
  - Map $0800-$0FFF to RAM2
  - Map $1000-$1FFF to ROM
- Add test cases for all chip selects

This design is a little heavy on '138s, but everything is functional.

To do:
- See about reducing chip count by using 2nd RTC CS input
- See about reducing chip count by replacing the 138 for A12-A10 with a
  few gates, since ~A12 = ~ROMCS and ~(~A12 & A11) = ~RAM2CS
- See about reducing chip count by using address lines for '138 enable
  inputs; the '138s on A6-A4 each only use a single output